### PR TITLE
Adding a python36 s2i image

### DIFF
--- a/s2i-python36-subatomic/Dockerfile
+++ b/s2i-python36-subatomic/Dockerfile
@@ -1,0 +1,56 @@
+# Based heavily on the image from here https://github.com/sclorg/s2i-python-container
+# This image provides a Python 3.6 environment you can use to run your Python
+# applications.
+FROM centos/s2i-base-centos7
+
+EXPOSE 8080
+
+ENV PYTHON_VERSION=3.6 \
+    PATH=$HOME/.local/bin/:$PATH \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    PIP_NO_CACHE_DIR=off
+
+RUN INSTALL_PKGS="rh-python36 rh-python36-python-devel rh-python36-python-setuptools rh-python36-python-pip nss_wrapper \
+        httpd24 httpd24-httpd-devel httpd24-mod_ssl httpd24-mod_auth_kerb httpd24-mod_ldap \
+        httpd24-mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl enchant" && \
+    yum install -y centos-release-scl && \
+    yum -y --setopt=tsflags=nodocs install --enablerepo=centosplus $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    # Remove centos-logos (httpd dependency) to keep image size smaller.
+    rpm -e --nodeps centos-logos && \
+    yum -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
+RUN source scl_source enable rh-python36 && \
+    virtualenv ${APP_ROOT} && \
+    chown -R 1001:0 ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
+    rpm-file-permissions
+
+
+#Add the subatomic cert
+ADD https://raw.githubusercontent.com/absa-subatomic/local-hadron-collider/master/minishift-addons/subatomic/certs/subatomic.ca.crt /etc/subatomic.ca.crt
+
+RUN yum install ca-certificates && \
+    update-ca-trust force-enable && \
+    cp /etc/subatomic.ca.crt /etc/pki/ca-trust/source/anchors/ && \
+    update-ca-trust extract
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image.
+CMD $STI_SCRIPTS_PATH/usage

--- a/s2i-python36-subatomic/README.md
+++ b/s2i-python36-subatomic/README.md
@@ -1,0 +1,6 @@
+# Subatomic Python 3.6 S2I image
+This S2I image is based off the [Python 3.6 S2I](https://github.com/sclorg/s2i-python-container/tree/master/3.6) image from sclorg.
+
+It add the following:
+
+Subatomic Root CA from Local Hadron Collider for local development

--- a/s2i-python36-subatomic/root/opt/app-root/etc/generate_container_user
+++ b/s2i-python36-subatomic/root/opt/app-root/etc/generate_container_user
@@ -1,0 +1,19 @@
+# Set current user in nss_wrapper
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+
+    NSS_WRAPPER_PASSWD=/opt/app-root/etc/passwd
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cat /etc/passwd | sed -e 's/^default:/builder:/' > $NSS_WRAPPER_PASSWD
+
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=libnss_wrapper.so
+    export LD_PRELOAD
+fi

--- a/s2i-python36-subatomic/root/opt/app-root/etc/scl_enable
+++ b/s2i-python36-subatomic/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,6 @@
+# IMPORTANT: Do not add more content to this file unless you know what you are
+#            doing. This file is sourced everytime the shell session is opened.
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable httpd24 $NODEJS_SCL rh-python36
+source /opt/app-root/bin/activate

--- a/s2i-python36-subatomic/s2i/bin/assemble
+++ b/s2i-python36-subatomic/s2i/bin/assemble
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+function is_django_installed() {
+  python -c "import django" &>/dev/null
+}
+
+function should_collectstatic() {
+  is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
+}
+
+function virtualenv_bin() {
+  if head "/etc/redhat-release" | grep -q "^Fedora"; then
+    virtualenv-${PYTHON_VERSION} $1
+  else
+    virtualenv $1
+  fi
+}
+
+# Install pipenv to the separate virtualenv to isolate it
+# from system Python packages and packages in the main
+# virtualenv. Executable is simlinked into ~/.local/bin
+# to be accessible. This approach is inspired by pipsi
+# (pip script installer).
+function install_pipenv() {
+  echo "---> Installing pipenv packaging tool ..."
+  VENV_DIR=$HOME/.local/venvs/pipenv
+  virtualenv_bin "$VENV_DIR"
+  $VENV_DIR/bin/pip --isolated install -U pipenv
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+}
+
+set -e
+
+shopt -s dotglob
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+  echo "---> Upgrading pip to latest version ..."
+  pip install -U pip setuptools wheel
+fi
+
+if [[ ! -z "$ENABLE_PIPENV" ]]; then
+  install_pipenv
+  echo "---> Installing dependencies via pipenv ..."
+  if [[ -f Pipfile ]]; then
+    pipenv install --deploy
+  elif [[ -f requirements.txt ]]; then
+    pipenv install -r requirements.txt
+  fi
+  # pipenv check
+elif [[ -f requirements.txt ]]; then
+  echo "---> Installing dependencies ..."
+  pip install -r requirements.txt
+fi
+
+if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then
+  echo "---> Installing application ..."
+  pip install .
+fi
+
+if should_collectstatic; then
+  (
+    echo "---> Collecting Django static files ..."
+
+
+    APP_HOME=${APP_HOME:-.}
+    # Look for 'manage.py' in the directory specified by APP_HOME, or the current directory
+    manage_file=$APP_HOME/manage.py
+
+    if [[ ! -f "$manage_file" ]]; then
+      echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
+      echo "'manage.py collectstatic' ignored."
+      exit
+    fi
+
+    if ! python $manage_file collectstatic --dry-run --noinput &> /dev/null; then
+      echo "WARNING: could not run 'manage.py collectstatic'. To debug, run:"
+      echo "    $ python $manage_file collectstatic --noinput"
+      echo "Ignore this warning if you're not serving static files with Django."
+      exit
+    fi
+
+    python $manage_file collectstatic --noinput
+  )
+fi
+
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root

--- a/s2i-python36-subatomic/s2i/bin/run
+++ b/s2i-python36-subatomic/s2i/bin/run
@@ -1,0 +1,106 @@
+#!/bin/bash
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+function is_gunicorn_installed() {
+  hash gunicorn &>/dev/null
+}
+
+function is_django_installed() {
+  python -c "import django" &>/dev/null
+}
+
+function should_migrate() {
+  is_django_installed && [[ -z "$DISABLE_MIGRATE" ]]
+}
+
+# Guess the number of workers according to the number of cores
+function get_default_web_concurrency() {
+  limit_vars=$(cgroup-limits)
+  local $limit_vars
+  if [ -z "${NUMBER_OF_CORES:-}" ]; then
+    echo 1
+    return
+  fi
+
+  local max=$((NUMBER_OF_CORES*2))
+  # Require at least 43 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
+  default=$((default > max ? max : default))
+  default=$((default < 1 ? 1 : default))
+  # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,
+  # 12 workers should be enough to handle hundreds or thousands requests per second
+  default=$((default > 12 ? 12 : default))
+  echo $default
+}
+
+app_script_check="${APP_SCRIPT-}"
+APP_SCRIPT="${APP_SCRIPT-app.sh}"
+if [[ -f "$APP_SCRIPT" ]]; then
+  echo "---> Running application from script ($APP_SCRIPT) ..."
+  if [[ "$APP_SCRIPT" != /* ]]; then
+    APP_SCRIPT="./$APP_SCRIPT"
+  fi
+  exec "$APP_SCRIPT"
+else
+  test -n "$app_script_check" && (>&2 echo "ERROR: file '$app_script_check' not found.") && exit 1
+fi
+
+app_file_check="${APP_FILE-}"
+APP_FILE="${APP_FILE-app.py}"
+if [[ -f "$APP_FILE" ]]; then
+  echo "---> Running application from Python script ($APP_FILE) ..."
+  exec python "$APP_FILE"
+else
+  test -n "$app_file_check" && (>&2 echo "ERROR: file '$app_file_check' not found.") && exit 1
+fi
+
+APP_HOME=${APP_HOME:-.}
+# Look for 'manage.py' in the directory specified by APP_HOME, or the current direcotry
+manage_file=$APP_HOME/manage.py
+
+if should_migrate; then
+  if [[ -f "$manage_file" ]]; then
+    echo "---> Migrating database ..."
+    python "$manage_file" migrate --noinput
+  else
+    echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
+    echo "Skipped 'python manage.py migrate'."
+  fi
+fi
+
+if is_gunicorn_installed; then
+  if [[ -z "$APP_MODULE" ]]; then
+    # Look only in the directory specified by APP_HOME, or the current directory
+    # replace all "/" with ".", remove leading "." and ".py" suffix
+    APP_MODULE=$(find $APP_HOME -maxdepth 1 -type f -name 'wsgi.py' | sed 's:/:.:g;s:^\.\+::;s:\.py$::')
+  fi
+
+  if [[ -z "$APP_MODULE" && -f setup.py ]]; then
+    APP_MODULE="$(python setup.py --name)"
+  fi
+
+  if [[ "$APP_MODULE" ]]; then
+    export WEB_CONCURRENCY=${WEB_CONCURRENCY:-$(get_default_web_concurrency)}
+
+    echo "---> Serving application with gunicorn ($APP_MODULE) ..."
+    exec gunicorn "$APP_MODULE" --bind=0.0.0.0:8080 --access-logfile=- --config "$APP_CONFIG"
+  fi
+fi
+
+if is_django_installed; then
+  if [[ -f "$manage_file" ]]; then
+    echo "---> Serving application with 'manage.py runserver' ..."
+    echo "WARNING: this is NOT a recommended way to run you application in production!"
+    echo "Consider using gunicorn or some other production web server."
+    exec python "$manage_file" runserver 0.0.0.0:8080
+  else
+    echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
+    echo "Skipped 'python manage.py runserver'."
+  fi
+fi
+
+>&2 echo "ERROR: don't know how to run your application."
+>&2 echo "Please set either APP_MODULE, APP_FILE or APP_SCRIPT environment variables, or create a file 'app.py' to launch your application."
+exit 1

--- a/s2i-python36-subatomic/s2i/bin/usage
+++ b/s2i-python36-subatomic/s2i/bin/usage
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
+
+cat <<EOF
+This is a S2I python-3.6 ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ ${NAMESPACE}/python-36-${DISTRO}7 python-sample-app
+
+
+You can then run the resulting image via:
+docker run -p 8080:8080 python-sample-app
+EOF


### PR DESCRIPTION
Added a Python36 s2i image. Based off the images sclorg [here](https://github.com/sclorg/s2i-python-container). According to the SO answer [here](https://github.com/sclorg/s2i-python-container/tree/master/3.6), Python uses the default unix cert store so this adds the sub cert to that.

Will follow up the PR with an associated maven slave and perhaps adding this to the LHC setup.