### PR TITLE
Update jenkins

### DIFF
--- a/jenkins-slave/dotnet22/Dockerfile
+++ b/jenkins-slave/dotnet22/Dockerfile
@@ -1,5 +1,5 @@
 # Based on https://github.com/redhat-developer/dotnet-jenkins-slave
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="rh-dotnet22-jenkins-slave-docker" \

--- a/jenkins-slave/maven/Dockerfile
+++ b/jenkins-slave/maven/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-maven-centos7:v3.9
+FROM openshift/jenkins-slave-maven-centos7:v3.11
 
 LABEL subatomic-version="2.0" \
         role=jenkins-slave

--- a/jenkins-slave/nodejs/Dockerfile
+++ b/jenkins-slave/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/absa-subatomic/laboratory/issues/19
-FROM openshift/jenkins-slave-nodejs-centos7:v3.9
+FROM openshift/jenkins-slave-nodejs-centos7:v3.11
 
 LABEL subatomic-version="2.0" \
         role=jenkins-slave

--- a/jenkins-slave/python36/Dockerfile
+++ b/jenkins-slave/python36/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/absa-subatomic/laboratory/issues/19
-FROM openshift/jenkins-slave-base-centos7:v3.9
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 LABEL subatomic-version="2.0" \
         role=jenkins-slave

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-2-centos7:v3.9
+FROM openshift/jenkins-2-centos7:v3.11
 
 LABEL subatomic-version="2.1"
 

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -3,7 +3,7 @@ openshift-pipeline:1.0.55
 openshift-login:1.0.9
 #openshift-login:1.0.10 - DO NOT upgrade. Causes NPE in org.openshift.jenkins.plugins.openshiftlogin.OpenShiftOAuth2SecurityRealm.postSAR(OpenShiftOAuth2SecurityRealm.java:606
 openshift-client:1.0.21
-openshift-sync:1.0.29
+openshift-sync:1.0.37
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
 kubernetes:1.8.4

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -9,9 +9,9 @@ openshift-sync:1.0.29
 kubernetes:1.8.4
 kubernetes-credentials:0.4.0
 
-blueocean:1.5.4
-blueocean-autofavorite:1.2.2
-blueocean-display-url:2.2.0
+blueocean:1.16.0
+blueocean-autofavorite:1.2.4
+blueocean-display-url:2.3.0
 
 workflow-api:2.27
 workflow-aggregator:2.5

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -1,7 +1,6 @@
 # OpenShift plugins - https://github.com/openshift/jenkins-client-plugin
 openshift-pipeline:1.0.55
-openshift-login:1.0.9
-#openshift-login:1.0.10 - DO NOT upgrade. Causes NPE in org.openshift.jenkins.plugins.openshiftlogin.OpenShiftOAuth2SecurityRealm.postSAR(OpenShiftOAuth2SecurityRealm.java:606
+openshift-login:1.0.18
 openshift-client:1.0.21
 openshift-sync:1.0.37
 

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -78,6 +78,6 @@ mailer:1.22
 favorite:2.3.2
 pipeline-graph-analysis:1.7
 scm-api:2.4.1
-sse-gateway:1.16
+sse-gateway:1.17
 ssh-credentials:1.14
 docker-workflow:1.17

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -71,7 +71,7 @@ git-client:2.7.3
 jsch:0.1.54.2
 junit:1.26.1
 structs:1.19
-branch-api:2.0.20
+branch-api:2.0.21
 pipeline-rest-api:2.10
 htmlpublisher:1.17
 mailer:1.22

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -18,9 +18,9 @@ workflow-aggregator:2.5
 workflow-scm-step:2.7
 workflow-job:2.32
 workflow-cps:2.58
-workflow-multibranch:2.20
+workflow-multibranch:2.21
 workflow-cps-global-lib:2.12
-workflow-durable-task-step:2.22
+workflow-durable-task-step:2.26
 workflow-support:3.2
 workflow-remote-loader:1.4
 workflow-step-api:2.19
@@ -36,7 +36,7 @@ credentials:2.1.18
 git:3.9.1
 job-dsl:1.70
 jira:3.0.5
-cloudbees-folder:6.5.1
+cloudbees-folder:6.6
 pipeline-stage-view:2.10
 pipeline-stage-step:2.3
 apache-httpcomponents-client-4-api:4.5.5-3.0
@@ -62,7 +62,7 @@ pipeline-model-api:1.3.2
 pipeline-stage-tags-metadata:1.3.2
 plain-credentials:1.4
 run-condition:1.2
-script-security:1.48
+script-security:1.58
 subversion:2.12.1
 token-macro:2.5
 maven-plugin:3.1.2
@@ -70,14 +70,14 @@ javadoc:1.4
 git-client:2.7.3
 jsch:0.1.54.2
 junit:1.26.1
-structs:1.17
+structs:1.19
 branch-api:2.0.20
 pipeline-rest-api:2.10
 htmlpublisher:1.17
 mailer:1.22
 favorite:2.3.2
 pipeline-graph-analysis:1.7
-scm-api:2.3.0
+scm-api:2.4.1
 sse-gateway:1.16
 ssh-credentials:1.14
 docker-workflow:1.17

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -17,13 +17,13 @@ workflow-api:2.27
 workflow-aggregator:2.5
 workflow-scm-step:2.7
 workflow-job:2.32
-workflow-cps:2.57
+workflow-cps:2.58
 workflow-multibranch:2.20
 workflow-cps-global-lib:2.12
 workflow-durable-task-step:2.22
-workflow-support:2.20
+workflow-support:3.2
 workflow-remote-loader:1.4
-workflow-step-api:2.16
+workflow-step-api:2.19
 # Cannot upgrade to workflow-api:2.28 must have +2.121
 workflow-basic-steps:2.8.2
 

--- a/jenkins/base-plugins.txt
+++ b/jenkins/base-plugins.txt
@@ -16,7 +16,7 @@ blueocean-display-url:2.3.0
 workflow-api:2.27
 workflow-aggregator:2.5
 workflow-scm-step:2.7
-workflow-job:2.25
+workflow-job:2.32
 workflow-cps:2.57
 workflow-multibranch:2.20
 workflow-cps-global-lib:2.12
@@ -48,7 +48,7 @@ durable-task:1.27
 github-api:1.92
 github-branch-source:2.4.1
 github:1.29.3
-jackson2-api:2.9.7.1
+jackson2-api:2.9.8
 ace-editor:1.1
 handlebars:1.1.1
 momentjs:1.1.1

--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -1,4 +1,4 @@
-cloudbees-bitbucket-branch-source:2.2.14
+cloudbees-bitbucket-branch-source:2.4.4
 bitbucket-scm-trait-commit-skip:0.1.1
 pegdown-formatter:1.3
 jacoco:3.0.4


### PR DESCRIPTION
Updated Jenkins images to the latest 3.11 versions. These appear to run much better on minishift than the older versions. Necessary plugin updates have been performed too.